### PR TITLE
eliminate warnings in PHP logs by not calling array_key_exists on null

### DIFF
--- a/SDK/RootsratedSDK.php
+++ b/SDK/RootsratedSDK.php
@@ -20,13 +20,14 @@ class RootsRatedSDK {
     }
 
     public function setConfig($configJson) {
-      if (!$configJson) {
-        return;
+      if (is_string($configJson)) {
+        $rootsrated = json_decode($configJson, true);
+      } else {
+        $rootsrated = $configJson;
       }
 
-      $rootsrated = $configJson;
-      if (is_string($configJson)) {
-          $rootsrated = json_decode($configJson, true);
+      if (!$rootsrated || !$rootsrated['rootsrated']) {
+        return;
       }
 
       if(array_key_exists('image_upload_path', $rootsrated['rootsrated']))

--- a/SDK/RootsratedSDK.php
+++ b/SDK/RootsratedSDK.php
@@ -19,45 +19,46 @@ class RootsRatedSDK {
         $this->setConfig($configJson);
     }
 
-    public function setConfig($configJson)
-    {
+    public function setConfig($configJson) {
+      if (!$configJson) {
+        return;
+      }
 
-        $rootsrated = $configJson;
-        if (is_string($configJson))
-        {
-            $rootsrated = json_decode($configJson, true);
-        }
+      $rootsrated = $configJson;
+      if (is_string($configJson)) {
+          $rootsrated = json_decode($configJson, true);
+      }
 
-        if(array_key_exists('image_upload_path',$rootsrated['rootsrated']))
-        {
-            $this->setImageUploadPath($rootsrated['rootsrated']['image_upload_path']);
-        }
+      if(array_key_exists('image_upload_path', $rootsrated['rootsrated']))
+      {
+          $this->setImageUploadPath($rootsrated['rootsrated']['image_upload_path']);
+      }
 
-        if(array_key_exists('rootsrated_key',$rootsrated['rootsrated']) &&
-            array_key_exists('rootsrated_secret',$rootsrated['rootsrated']))
-        {
-            $this->setKeyAndSecret($rootsrated['rootsrated']['rootsrated_key'], $rootsrated['rootsrated']['rootsrated_secret']);
-        }
+      if(array_key_exists('rootsrated_key', $rootsrated['rootsrated']) &&
+          array_key_exists('rootsrated_secret', $rootsrated['rootsrated']))
+      {
+          $this->setKeyAndSecret($rootsrated['rootsrated']['rootsrated_key'], $rootsrated['rootsrated']['rootsrated_secret']);
+      }
 
-        if(array_key_exists('rootsrated_token',$rootsrated['rootsrated']))
-        {
-            $this->setToken($rootsrated['rootsrated']['rootsrated_token']);
-        }
+      if(array_key_exists('rootsrated_token', $rootsrated['rootsrated']))
+      {
+          $this->setToken($rootsrated['rootsrated']['rootsrated_token']);
+      }
 
-        if(array_key_exists('phone_home_url',$rootsrated['rootsrated']))
-        {
-            $this->setPhoneHomeUrl($rootsrated['rootsrated']['phone_home_url']);
-        }
+      if(array_key_exists('phone_home_url',$rootsrated['rootsrated']))
+      {
+          $this->setPhoneHomeUrl($rootsrated['rootsrated']['phone_home_url']);
+      }
 
-        if(array_key_exists('posttype',$rootsrated['rootsrated']))
-        {
-            $this->setPostType($rootsrated['rootsrated']['posttype']);
-        }
+      if(array_key_exists('posttype',$rootsrated['rootsrated']))
+      {
+          $this->setPostType($rootsrated['rootsrated']['posttype']);
+      }
 
-        if(array_key_exists('application_path',$rootsrated['rootsrated']))
-        {
-            $this->setApplicationPath($rootsrated['rootsrated']['application_path']);
-        }
+      if(array_key_exists('application_path',$rootsrated['rootsrated']))
+      {
+          $this->setApplicationPath($rootsrated['rootsrated']['application_path']);
+      }
     }
 
     // Getters and Setters


### PR DESCRIPTION
This function gets called by the WordPress plugin before these values are set (i.e., during activation, before authentication), leading to warnings in the PHP error_log like the following:

```
[Tue May 14 16:44:19.635782 2019] [proxy_fcgi:error] [pid 23142:tid 139814053500672] [client 73.7.168.206:53552] AH01071: Got error 'PHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 31\nPHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 36\nPHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 42\nPHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 47\nPHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 52\nPHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /opt/bitnami/apps/wordpress/htdocs/wp-content/plugins/rootsrated-content-cloud/includes/SDK/RootsratedSDK.php on line 57\n'
```

PHP handles this, but the log warnings can cause customers to think there is a problem.